### PR TITLE
fix(#1): Using useRef to fix reconnect issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,15 @@
-import { useState, useEffect } from "react";
+import { useEffect, useRef } from "react";
 import io from "socket.io-client";
 
 const useSocket = (...args) => {
-  const [socket, setSocket] = useState(io(...args));
+  const { current: socket } = useRef(io(...args));
   useEffect(() => {
     return () => {
-      socket.removeAllListeners();
-      socket.close();
+      socket && socket.removeAllListeners();
+      socket && socket.close();
     };
   }, [socket]);
-  return [socket, setSocket];
+  return [socket];
 };
 
 export default useSocket;


### PR DESCRIPTION
## Goal
Using `useRef` instead of `useState`, cause the constrcuted instance will not same reference to current.

## Note
Also add defensive check to handle the instance unexpected destroyed case. (somehow it's deleted outside).