### PR TITLE
fix: multiple connections issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,8 @@ export const useSocket = (...args) => {
     setSocket(() => io(...args));
 
     return () => {
-      socket?.removeAllListeners();
-      socket?.close();
+      socket && socket.removeAllListeners();
+      socket && socket.close();
     };
   }, []);
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,17 @@
-import { useEffect, useRef } from "react";
-import io from "socket.io-client";
+import { useEffect, useState } from 'react';
+import io from 'socket.io-client';
 
-const useSocket = (...args) => {
-  const { current: socket } = useRef(io(...args));
+export const useSocket = (...args) => {
+  const [socket, setSocket] = useState(null);
+
   useEffect(() => {
+    setSocket(() => io(...args));
+
     return () => {
-      socket && socket.removeAllListeners();
-      socket && socket.close();
+      socket?.removeAllListeners();
+      socket?.close();
     };
-  }, [socket]);
+  }, []);
+
   return [socket];
 };
-
-export default useSocket;

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ export const useSocket = (...args) => {
   const [socket, setSocket] = useState(null);
 
   useEffect(() => {
-    setSocket(() => io(...args));
+    setSocket(io(...args));
 
     return () => {
       socket && socket.removeAllListeners();


### PR DESCRIPTION
This pull request aims to fix #1. I saw an old PR (#2) trying to fix this same issue using refs, but the problem with that was that it was setting the `ref` inside the render function and not inside an `useEffect` hook, therefore, it was creating a new connection of socket.io in each render. 

The approach that I followed was creating and storing the instance of socket.io inside an `useEffect` hook. The only caveat that this approach has is that in the first render it will return a null value and after that, the socket instance; this because of the `useEffect` hook.