### PR TITLE
fix: multiple connections WITHOUT initial null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,8 @@ export const useSocket = (...args) => {
     setSocket(() => io(...args));
 
     return () => {
-      socket?.removeAllListeners();
-      socket?.close();
+      socket && socket.removeAllListeners();
+      socket && socket.close();
     };
   }, []);
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,17 @@
-import { useEffect, useRef } from "react";
-import io from "socket.io-client";
+import { useEffect, useState } from 'react';
+import io from 'socket.io-client';
 
-const useSocket = (...args) => {
-  const { current: socket } = useRef(io(...args));
+export const useSocket = (...args) => {
+  const [socket, setSocket] = useState(null);
+
   useEffect(() => {
+    setSocket(() => io(...args));
+
     return () => {
-      socket && socket.removeAllListeners();
-      socket && socket.close();
+      socket?.removeAllListeners();
+      socket?.close();
     };
-  }, [socket]);
+  }, []);
+
   return [socket];
 };
-
-export default useSocket;

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ export const useSocket = (...args) => {
   const [socket, setSocket] = useState(null);
 
   useEffect(() => {
-    setSocket(() => io(...args));
+    setSocket(io(...args));
 
     return () => {
       socket && socket.removeAllListeners();

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,9 @@ import { useEffect, useState } from 'react';
 import io from 'socket.io-client';
 
 export const useSocket = (...args) => {
-  const [socket, setSocket] = useState(null);
+  const [socket] = useState(() => io(...args));
 
   useEffect(() => {
-    setSocket(io(...args));
 
     return () => {
       socket && socket.removeAllListeners();


### PR DESCRIPTION
Improves on #3 by not initializing socket as null.

- Instead, I pass to "useState( )" a function that returns the socket object from "io(...args)".
- Only one socket connection will be made. Since the initial value is a function, it will only be ran once.
- This simplifies the code by eliminating the need for "setSocket"